### PR TITLE
Fixed failing build on linux

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -11,9 +11,6 @@
       "dependencies": [
         "<!(node -p \"require('node-addon-api').gyp\")"
       ], 
-      "sources": [
-        "src/IconExtractor.cpp"
-      ],
       "msvs_settings": {
         "VCCLCompilerTool": {
           "ExceptionHandling": 1
@@ -22,6 +19,7 @@
       "conditions": [
         ['OS=="win"', {
           'sources': [
+      "src/IconExtractor.cpp"
 	    "src/IconExtractorWindows.cpp"
           ],
           "libraries": [


### PR DESCRIPTION
IconExtractor.cpp is only implemented for windows so it should only be compiled on windows 